### PR TITLE
feature for using txt files as source and target

### DIFF
--- a/taln/taln_aln.py
+++ b/taln/taln_aln.py
@@ -10,6 +10,8 @@ import json
 
 import logging
 
+from taln.utils import load_text
+
 logger = logging.getLogger(__name__)
 
 
@@ -24,7 +26,7 @@ def setup_taln_aln_args(parser):
         "-s",
         "--source",
         type=str,
-        help="Source text to align",
+        help="Source text to align as str or .txt",
         required=True,
     )
     subparser.add_argument(
@@ -50,14 +52,14 @@ def setup_taln_aln_args(parser):
     subparser.add_argument(
         "target",
         type=str,
-        help="Target text to align",
+        help="Target text to align as str or .txt",
     )
     return subparser
 
 
 def validate_taln_aln_args(parser, args):
-    src = args.source
-    tgt = args.target
+    src = load_text(args.source)
+    tgt = load_text(args.target)
     ttype = args.tokenization_type
     output = args.output
     sng = args.single
@@ -72,7 +74,7 @@ def validate_taln_aln_args(parser, args):
             json.dump(alns, f, indent=4)
     else:
         print(json.dumps(alns, indent=4))
-    return
+    pass
 
 
 def norm_text(text):

--- a/taln/taln_light.py
+++ b/taln/taln_light.py
@@ -1,5 +1,5 @@
 from taln.taln_aln import align_ng
-
+from taln.utils import load_text
 
 # add functionality to check if the source and target are paths to files
 def setup_taln_light_args(parser):
@@ -11,7 +11,7 @@ def setup_taln_light_args(parser):
         "-s",
         "--source",
         type=str,
-        help="Source text to align",
+        help="Source text to align as str or .txt",
         required=True,
     )
     subparser.add_argument(
@@ -32,14 +32,14 @@ def setup_taln_light_args(parser):
     subparser.add_argument(
         "target",
         type=str,
-        help="Target text to align",
+        help="Target text to align as str or .txt",
     )
     return subparser
 
 
 def validate_taln_light_args(parser, args):
-    src = args.source
-    tgt = args.target
+    src = load_text(args.source)
+    tgt = load_text(args.target)
     ttype = args.tokenization_type
     alns = align_ng(src, tgt, ttype)
     output = args.output

--- a/taln/utils.py
+++ b/taln/utils.py
@@ -1,0 +1,7 @@
+import os
+
+def load_text(input_str):
+    if os.path.isfile(input_str) and input_str.endswith('.txt'):
+        with open(input_str, 'r', encoding='utf-8') as f:
+            return f.read()
+    return input_str  # assume direct text input


### PR DESCRIPTION
Adds method load_text in utils.py to load text from txt files

Side note:
- Python 3.10 works as well
- dependencies could be reduced: ollama and pandas are not needed